### PR TITLE
Updated shearable blocks to allow modded shears to harvest them

### DIFF
--- a/src/main/resources/data/byg/loot_tables/blocks/araucaria_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/araucaria_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/aspen_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/aspen_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/baobab_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/baobab_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/beach_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/beach_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/blooming_witch_hazel_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/blooming_witch_hazel_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/blue_enchanted_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/blue_enchanted_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/blue_spruce_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/blue_spruce_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/brown_birch_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/brown_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/brown_oak_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/brown_oak_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/brown_zelkova_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/brown_zelkova_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/cika_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/cika_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/clover_patch.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/clover_patch.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/cryptic_bramble.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/cryptic_bramble.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/cypress_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/cypress_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/ebony_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ebony_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/embur_sprouts.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/embur_sprouts.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/ether_bush.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ether_bush.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/ether_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ether_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/ether_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ether_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/fir_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/fir_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/flower_patch.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flower_patch.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/flowering_indigo_jacaranda_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flowering_indigo_jacaranda_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/flowering_jacaranda_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flowering_jacaranda_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/flowering_nightshade_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flowering_nightshade_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/flowering_orchard_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flowering_orchard_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/flowering_palo_verde_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/flowering_palo_verde_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/fungal_imparius_filament.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/fungal_imparius_filament.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/green_apple_skyris_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/green_apple_skyris_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/green_enchanted_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/green_enchanted_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/holly_berry_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/holly_berry_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/holly_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/holly_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/imparius_bush.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/imparius_bush.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/indigo_jacaranda_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/indigo_jacaranda_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/jacaranda_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/jacaranda_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/joshua_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/joshua_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/lament_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/lament_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/lament_sprouts.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/lament_sprouts.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/leaf_pile.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/leaf_pile.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/mahogany_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/mahogany_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/mangrove_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/mangrove_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/maple_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/nightshade_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/nightshade_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/nightshade_sprouts.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/nightshade_sprouts.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/oddity_bush.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/oddity_bush.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/orange_birch_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/orange_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/orange_oak_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/orange_oak_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/orange_spruce_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/orange_spruce_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/orchard_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/orchard_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/palm_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/palm_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/palo_verde_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/palo_verde_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/pine_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/pine_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/pink_cherry_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/pink_cherry_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/poison_ivy.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/poison_ivy.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/prairie_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/prairie_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/rainbow_eucalyptus_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/rainbow_eucalyptus_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/red_birch_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/red_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/red_maple_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/red_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/red_oak_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/red_oak_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/red_spruce_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/red_spruce_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/redwood_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/redwood_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/ripe_joshua_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ripe_joshua_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/ripe_orchard_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/ripe_orchard_leaves.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/scorched_bush.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/scorched_bush.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/scorched_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/scorched_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/short_beach_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/short_beach_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/short_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/short_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/shulkren_moss_blanket.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/shulkren_moss_blanket.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/shulkren_vine.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/shulkren_vine.json
@@ -13,7 +13,7 @@
         {                                     
           "condition": "minecraft:match_tool",
           "predicate": {                      
-            "item": "minecraft:shears"        
+            "tag": "forge:shears"        
           }                                   
         }                                     
       ]                                       

--- a/src/main/resources/data/byg/loot_tables/blocks/silver_maple_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/silver_maple_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/skyris_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/skyris_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {
@@ -157,7 +157,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/skyris_vine.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/skyris_vine.json
@@ -13,7 +13,7 @@
         {                                     
           "condition": "minecraft:match_tool",
           "predicate": {                      
-            "item": "minecraft:shears"        
+            "tag": "forge:shears"        
           }                                   
         }                                     
       ]                                       

--- a/src/main/resources/data/byg/loot_tables/blocks/tall_ether_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/tall_ether_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],
@@ -75,7 +75,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/tall_prairie_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/tall_prairie_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/vermilion_sculk_growth.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/vermilion_sculk_growth.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/warped_bush.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/warped_bush.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/water_silk.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/water_silk.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/weed_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/weed_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/whaling_vine.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/whaling_vine.json
@@ -13,7 +13,7 @@
         {
           "condition": "minecraft:match_tool",
           "predicate": {
-            "item": "minecraft:shears"
+            "tag": "forge:shears"
           }
         }
       ]

--- a/src/main/resources/data/byg/loot_tables/blocks/white_cherry_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/white_cherry_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/willow_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/willow_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/wilted_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/wilted_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/winter_grass.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/winter_grass.json
@@ -13,7 +13,7 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "item": "minecraft:shears"
+                    "tag": "forge:shears"
                   }
                 }
               ],

--- a/src/main/resources/data/byg/loot_tables/blocks/witch_hazel_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/witch_hazel_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/withering_oak_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/withering_oak_leaves.json
@@ -14,7 +14,7 @@
                   "terms": [
                     {
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       },
                       "condition": "minecraft:match_tool"
                     },
@@ -99,7 +99,7 @@
             "terms": [
               {
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 },
                 "condition": "minecraft:match_tool"
               },

--- a/src/main/resources/data/byg/loot_tables/blocks/yellow_birch_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/yellow_birch_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/yellow_spruce_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/yellow_spruce_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {

--- a/src/main/resources/data/byg/loot_tables/blocks/zelkova_leaves.json
+++ b/src/main/resources/data/byg/loot_tables/blocks/zelkova_leaves.json
@@ -16,7 +16,7 @@
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "item": "minecraft:shears"
+                        "tag": "forge:shears"
                       }
                     },
                     {
@@ -103,7 +103,7 @@
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "item": "minecraft:shears"
+                  "tag": "forge:shears"
                 }
               },
               {


### PR DESCRIPTION
When Shears from other mods, Botania for example, are used on BYG blocks that require shears to harvest, they drop nothing. This PR fixes that by changing the match tool predicate to `"tag": "forge:shears"`, which all modded Shears should be in.